### PR TITLE
More DRY, uses splatting, added help, changed output type, updated README

### DIFF
--- a/Get-Uptime.ps1
+++ b/Get-Uptime.ps1
@@ -1,46 +1,38 @@
-Function Get-uptime
+Function Get-Uptime
 {
-	
 	[CmdletBinding()]
-	[OutputType([int])]
+	[OutputType([System.TimeSpan])]
 	Param
 	(
-		# Param1 help description
-		[Parameter(Mandatory = $false,
-				   Position = 0)]
-		[string[]]$ComputerName
-		
+		[Parameter(
+            Mandatory = $false,
+	        Position = 0
+        )]
+        [ValidateNotNullOrEmpty()]
+		[String[]]
+        $ComputerName
 	)
 	
-	if ($ComputerName -ne $null)
-	{
-		
-		
-		
-		# Try one or more commands
-		try
-		{
-			$os = Get-wmiobject -ComputerName $ComputerName win32_operatingsystem -ErrorAction stop
-			$uptime = (get-date) - ($os.ConvertTodateTime($os.lastbootuptime))
-			$display = $uptime.days
-			write-output $display
-		}
-		# Catch specific types of exceptions thrown by one of those commands
-        catch {
-            Write-Warning "Machine $Computername is offline" -ForegroundColor Yellow -BackgroundColor Black
-        }
+    $params = @{
+        Class = 'Win32_OperatingSystem'
+    }
+    if ($ComputerName) {
+        $params.ComputerName = $ComputerName
+    }
 
-	}
+	$os = Get-WmiObject @params
 	
-	
-	else
-	{
+    (Get-Date) - ($os.ConvertTodateTime($os.LastBootUpTime))
 		
-		$os = Get-wmiobject win32_operatingsystem
-		$uptime = (get-date) - ($os.ConvertTodateTime($os.lastbootuptime))
-		$display = $uptime.days
-		write-output $display
-		
-		
-	}
+<#
+.SYNOPSIS
+Gets the uptime for one or more computers.
+
+.PARAMETER ComputerName
+The name(s) of the computer(s) for which uptime is needed. If not specified, the local computer is checked.
+
+.LINK
+https://github.com/itadder/Get-Uptime
+
+#>
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,49 @@
 # Get-Uptime
-Get-Uptime -ComputerName localhost
-It will display Computer uptime for local or remote host.
-It is a simple not fancy script.
+
+See `Get-Help Get-Uptime`:
+
+
+```
+
+NAME
+    Get-Uptime
+    
+SYNOPSIS
+    Gets the uptime for one or more computers.
+    
+SYNTAX
+    Get-Uptime [[-ComputerName] <String[]>] [<CommonParameters>]
+    
+    
+DESCRIPTION
+    
+
+PARAMETERS
+    -ComputerName <String[]>
+        The name(s) of the computer(s) for which uptime is needed. If not specified, the local computer is checked.
+        
+        Required?                    false
+        Position?                    1
+        Default value                
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
+        
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see 
+        about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216). 
+    
+INPUTS
+    
+OUTPUTS
+    System.TimeSpan
+        
+    
+    
+    
+    
+RELATED LINKS
+    https://github.com/itadder/Get-Uptime
+
+```


### PR DESCRIPTION
I know these are some major changes, but I think they're useful.

The big breaking change is changing the output type to a `[TimeSpan]`. I think this is important; it's more versatile and contains more information. One can easily get the days out of the timespan returned, or use it directly for something that needs a timespan, but one cannot get the missing information if a number of days is returned.